### PR TITLE
Add Backlog style

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ https://chrome.google.com/webstore/detail/cefkgjbbpagcilodnhboolbppdjlplip
 ## Features
 - Simple and Fast
 - It can copy as markdown style.
+- It can copy as [Backlog](https://www.backlog.com/) style.
 - It can copy and open menu by shotcut(ctrl+shift+c)
 - It can exclude query strings, and trim Japanese Amazon's verbose URL.
 

--- a/simple-url-copy/popup.html
+++ b/simple-url-copy/popup.html
@@ -49,6 +49,11 @@
         Markdown Style
       </span>
     </div>
+    <div id="backlog" class="mdl-card__actions mdl-card--border bettercopy-menu">
+      <span class="mdl-button mdl-button--colored mdl-js-button mdl-js-ripple-effect">
+        Backlog Style
+      </span>
+    </div>
     <div class="mdl-card__actions mdl-card--border bettercopy-copy">
       <textarea id="copy-textarea" class="mdl-button bettercopy-textarea"></textarea>
     </div>

--- a/simple-url-copy/popup.js
+++ b/simple-url-copy/popup.js
@@ -52,6 +52,9 @@ const copyUrl = menuType => {
       case "markdown":
         text = `[${title}](${url})`
         break;
+      case "backlog":
+        text = `[[${title}:${url}]]`
+        break;
       case "simple":
         text = `${title} ${url}`
         break;


### PR DESCRIPTION
I added Backlog style to simple-url-copy. Backlog is project management tool that is most popular in Japan. Backlog supports markdown style and Backlog  style. I think many backlog users want this feature. (me too 😄)  

## e.g.

Markdown style:
> \[Google](https://www.google.com)

Backlog style:
> [[Google:https://www.google.com]]

## Screenshot
![image](https://user-images.githubusercontent.com/40473/53856775-d6e06880-4016-11e9-970f-707ef6cafdfb.png)