### PR TITLE
Add Org mode style

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ https://chrome.google.com/webstore/detail/cefkgjbbpagcilodnhboolbppdjlplip
 ## Features
 - Simple and Fast
 - It can copy as markdown style.
+- It can copy as [Org mode](https://orgmode.org/) style.
 - It can copy and open menu by shotcut(ctrl+shift+c)
 - It can exclude query strings, and trim Japanese Amazon's verbose URL.
 

--- a/simple-url-copy/manifest.json
+++ b/simple-url-copy/manifest.json
@@ -1,14 +1,14 @@
 {
-  "name": "Simple URL Copy",
+  "name": "Markdown/Org URL Copy",
   "description": "A tool that help you to copy url.",
-  "author": "@ikedaosushi",
-  "version": "1.0.0.1",
-  "manifest_version": 2,
+  "author": "@wurly",
+  "version": "1.0.0",
+  "manifest_version": 3,
   "icons": {
     "16": "icons/16.png",
     "128": "icons/128.png"
   },
-  "browser_action": {
+  "action": {
     "default_popup": "popup.html",
     "default_icon": "icons/16.png"
   },
@@ -25,6 +25,8 @@
     "storage",
     "tabs"
   ],
-  "content_security_policy": "script-src 'self' https://code.getmdl.io; object-src 'self'",
+  "content_security_policy": {
+      "extension_pages": "script-src 'self'; object-src 'self'; script-src-elem 'self' 'unsafe-inline' https://code.getmdl.io;"
+  },
   "devtools_page": "popup.html"
 }

--- a/simple-url-copy/popup.html
+++ b/simple-url-copy/popup.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="utf-8">
-  <title>Simple URL Copy</title>
+  <title>Markdown/Org URL Copy</title>
   <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
   <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.indigo-pink.min.css">
   <link rel="stylesheet" href="popup.css">
@@ -14,7 +14,7 @@
 <body>
   <div class="demo-card-square mdl-card mdl-shadow--2dp">
     <div class="mdl-card__title mdl-card--expand">
-      <h2 class="mdl-card__title-text">Simple URL Copy</h2>
+      <h2 class="mdl-card__title-text">Markdown/Org URL Copy</h2>
     </div>
     <div class="mdl-card__supporting-text">
       <span>Ctrl+Shift+C can open this menu.</span>
@@ -34,24 +34,9 @@
         </label>
       </div> -->
     </div>
-    <div id="simple" class="mdl-card__actions mdl-card--border bettercopy-menu">
-      <span class="mdl-button mdl-button--colored mdl-js-button mdl-js-ripple-effect">
-        Title URL
-      </span>
-    </div>
-    <div id="with-newline" class="mdl-card__actions mdl-card--border bettercopy-menu">
-      <span class="mdl-button mdl-button--colored mdl-js-button mdl-js-ripple-effect">
-        Title<br>URL
-      </span>
-    </div>
     <div id="markdown" class="mdl-card__actions mdl-card--border bettercopy-menu">
       <span class="mdl-button mdl-button--colored mdl-js-button mdl-js-ripple-effect">
         Markdown Style
-      </span>
-    </div>
-    <div id="backlog" class="mdl-card__actions mdl-card--border bettercopy-menu">
-      <span class="mdl-button mdl-button--colored mdl-js-button mdl-js-ripple-effect">
-        Backlog Style
       </span>
     </div>
     <div id="org-mode" class="mdl-card__actions mdl-card--border bettercopy-menu">

--- a/simple-url-copy/popup.html
+++ b/simple-url-copy/popup.html
@@ -49,6 +49,11 @@
         Markdown Style
       </span>
     </div>
+    <div id="org-mode" class="mdl-card__actions mdl-card--border bettercopy-menu">
+      <span class="mdl-button mdl-button--colored mdl-js-button mdl-js-ripple-effect">
+        Org mode Style
+      </span>
+    </div>
     <div class="mdl-card__actions mdl-card--border bettercopy-copy">
       <textarea id="copy-textarea" class="mdl-button bettercopy-textarea"></textarea>
     </div>

--- a/simple-url-copy/popup.js
+++ b/simple-url-copy/popup.js
@@ -52,17 +52,8 @@ const copyUrl = menuType => {
       case "markdown":
         text = `[${title}](${url})`
         break;
-      case "backlog":
-        text = `[[${title}:${url}]]`
-        break;
       case "org-mode":
         text = `[[${url}][${title}]]`
-        break;
-      case "simple":
-        text = `${title} ${url}`
-        break;
-      case "with-newline":
-        text = `${title}\n${url}`
         break;
     }
     copyText(text);

--- a/simple-url-copy/popup.js
+++ b/simple-url-copy/popup.js
@@ -52,6 +52,9 @@ const copyUrl = menuType => {
       case "markdown":
         text = `[${title}](${url})`
         break;
+      case "org-mode":
+        text = `[[${url}][${title}]]`
+        break;
       case "simple":
         text = `${title} ${url}`
         break;


### PR DESCRIPTION
I added Org mode style to simple-url-copy. Org mode is a document editing, formatting, and organizing mode within the free software text editor Emacs.